### PR TITLE
 ci, docs: reliable changelog updates; bilingual Unreleased notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,11 +50,21 @@ jobs:
         env:
           CHANGELOG: ${{ github.event.release.body }}
         run: |
+          VERSION_RAW="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION_RAW#v}"
           RELEASE_NOTE="./build/tmp/release_note.txt"
           mkdir -p "$(dirname "$RELEASE_NOTE")"
           echo "$CHANGELOG" > $RELEASE_NOTE
 
           ./gradlew patchChangelog --release-note-file=$RELEASE_NOTE
+
+          # Patch Chinese changelog: rename Unreleased -> [VERSION] and add new Unreleased on top
+          if [ -f CHANGELOG_zh.md ]; then
+            awk -v ver="$VERSION" '
+              !done && $0 ~ /^## \[Unreleased\]\s*$/ { print "## [Unreleased]\n\n## [" ver "]"; done=1; next }
+              { print }
+            ' CHANGELOG_zh.md > CHANGELOG_zh.md.tmp && mv CHANGELOG_zh.md.tmp CHANGELOG_zh.md
+          fi
 
       # Publish the plugin to JetBrains Marketplace
       - name: Publish Plugin
@@ -71,30 +81,74 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*
 
-      # Create a pull request
-      - name: Create Pull Request
-        if: ${{ steps.properties.outputs.changelog != '' }}
+      # After successful publish, update main branch changelog via PR with auto-merge
+      - name: Check out main branch
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Patch Changelog on main
+        if: ${{ github.event.release.body != '' }}
+        env:
+          CHANGELOG: ${{ github.event.release.body }}
+        run: |
+          VERSION_RAW="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION_RAW#v}"
+          RELEASE_NOTE="./build/tmp/release_note.txt"
+          mkdir -p "$(dirname "$RELEASE_NOTE")"
+          echo "$CHANGELOG" > $RELEASE_NOTE
+
+          ./gradlew patchChangelog --release-note-file=$RELEASE_NOTE
+
+          # Patch Chinese changelog: rename Unreleased -> [VERSION] and add new Unreleased on top
+          if [ -f CHANGELOG_zh.md ]; then
+            awk -v ver="$VERSION" '
+              !done && $0 ~ /^## \[Unreleased\]\s*$/ { print "## [Unreleased]\n\n## [" ver "]"; done=1; next }
+              { print }
+            ' CHANGELOG_zh.md > CHANGELOG_zh.md.tmp && mv CHANGELOG_zh.md.tmp CHANGELOG_zh.md
+          fi
+
+      - name: Create PR for changelog update (auto-merge)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="${{ github.event.release.tag_name }}"
-          BRANCH="changelog-update-$VERSION"
+          VERSION_RAW="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION_RAW#v}"
+          BRANCH="changelog/update-$VERSION"
           LABEL="release changelog"
 
+          git switch -c "$BRANCH"
           git config user.email "action@github.com"
           git config user.name "GitHub Action"
 
-          git checkout -b $BRANCH
-          git commit -am "Changelog update - $VERSION"
-          git push --set-upstream origin $BRANCH
-          
-          gh label create "$LABEL" \
-            --description "Pull requests with release changelog update" \
-            --force \
-            || true
+          # Stage potential changelog files
+          git add CHANGELOG.md || true
+          if [ -f CHANGELOG_zh.md ]; then
+            git add CHANGELOG_zh.md || true
+          fi
 
-          gh pr create \
-            --title "Changelog update - \`$VERSION\`" \
-            --body "Current pull request contains patched \`CHANGELOG.md\` file for the \`$VERSION\` version." \
-            --label "$LABEL" \
-            --head $BRANCH
+          # Commit only if there are staged changes
+          if ! git diff --cached --quiet; then
+            git commit -m "chore(changelog): update for $VERSION"
+            git push --set-upstream origin "$BRANCH"
+
+            # Ensure label exists
+            gh label create "$LABEL" \
+              --description "Pull requests with release changelog update" \
+              --force \
+              || true
+
+            # Create PR targeting main
+            gh pr create \
+              --title "Changelog update - $VERSION" \
+              --body "This PR updates \`CHANGELOG.md\` replacing Unreleased with \`$VERSION\` and adds a new Unreleased section." \
+              --label "$LABEL" \
+              --base main \
+              --head "$BRANCH"
+
+            # Enable auto-merge (squash); will merge when checks pass
+            gh pr merge --auto --squash "$BRANCH" || true
+          else
+            echo "No changelog changes detected; skipping PR creation."
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@
 > [中文更新日志](./CHANGELOG_zh.md) | [Chinese Changelog](./CHANGELOG_zh.md)
 
 ## [Unreleased]
+### 🔧 CI/CD
+- 🔧 Update release workflow to patch `CHANGELOG.md` at the start of the release using `patchChangelog`, ensuring packaged change notes match the current version.
+- 🚀 After a successful publish, check out `main`, re-run the changelog patch, and open an auto-merge PR to update `main`.
+- 🇨🇳 Add Chinese changelog handling: automatically move Unreleased to the current version and insert a new Unreleased section for the next cycle.
+- ✅ Ensure `main` branch changelog only changes after a successful publish.
 
+## [2.2.0]
 ### ✨ Added
 - 🌟 Wildcard path matching for mock API paths
 - 🔹 Single-segment `*`: e.g., `/a/b/*` matches `/a/b/123` (not `/a/b/123/456`)

--- a/CHANGELOG_zh.md
+++ b/CHANGELOG_zh.md
@@ -5,7 +5,13 @@
 > [English Changelog](./CHANGELOG.md) | [英文更新日志](./CHANGELOG.md)
 
 ## [Unreleased]
+### 🔧 CI/CD
+- 🔧 发布工作流第一步执行 `patchChangelog`，确保打包到插件市场的 changeNotes 与当前版本一致。
+- 🚀 发布成功后检出 `main`，再次执行 changelog 更新，并创建 PR 自动合并以更新 `main`。
+- 🇨🇳 新增中文日志处理：自动将 Unreleased 归档到当前版本并插入新的 Unreleased，供下个版本编写。
+- ✅ 仅在发布成功后才变更 `main` 分支的 changelog。
 
+## [2.2.0]
 ### ✨ 新增
 - 🌟 Mock 接口路径支持通配匹配
 - 🔹 单段通配 `*`：如 `/a/b/*` 匹配 `/a/b/123`（不匹配 `/a/b/123/456`）

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = org.zhongmiao.interceptwave
 pluginName = Intercept Wave
 pluginRepositoryUrl = https://github.com/zhongmiao-org/intercept-wave
 # SemVer format -> https://semver.org
-pluginVersion = 2.2.0
+pluginVersion = 2.2.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 243


### PR DESCRIPTION
  - Pre-publish: patch CHANGELOG.md via gradle patchChangelog so packaged change notes match the release tag
  - Post-publish: checkout main, re‑patch, create auto‑merge PR; update main only after a successful publish
  - zh changelog: replace Perl multi-line with stable awk; promote Unreleased to current version and insert a new Unreleased
  - Docs: add CI/CD updates under Unreleased in both CHANGELOG.md and CHANGELOG_zh.md (🔧 🚀 🇨🇳 ✅)