### PR TITLE
Support IntelliJ 2023 and newer

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -60,3 +60,10 @@
   color: c5def5
   description: Pull requests with release changelog update
 
+- name: release
+  color: 5319e7
+  description: Release preparation and publishing changes
+
+- name: skip changelog
+  color: e4e669
+  description: Pull requests that do not require changelog updates

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,69 @@
+name: Changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changelog:
+    name: Require bilingual changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Sources
+        uses: actions/checkout@v6
+
+      - name: Check bilingual changelog updates
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.head_ref }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          has_label() {
+            local label="$1"
+            [[ ",${LABELS}," == *",${label},"* ]]
+          }
+
+          if [[ "$PR_AUTHOR" == "dependabot[bot]" ]]; then
+            echo "Dependabot PR detected; skipping changelog gate."
+            exit 0
+          fi
+
+          if [[ "$HEAD_REF" == changelog/update-* ]]; then
+            echo "Release changelog archive branch detected; skipping changelog gate."
+            exit 0
+          fi
+
+          if [[ "$HEAD_REF" == release/v* ]]; then
+            echo "Release PR branch detected; skipping changelog gate."
+            exit 0
+          fi
+
+          if has_label "skip changelog" || has_label "release changelog" || has_label "release"; then
+            echo "Changelog gate skipped by PR label."
+            exit 0
+          fi
+
+          changed_files="$(gh pr view "$PR_NUMBER" --json files --jq '.files[].path')"
+          echo "Changed files:"
+          echo "$changed_files"
+
+          if ! grep -qx 'CHANGELOG.md' <<< "$changed_files"; then
+            echo "::error::Missing CHANGELOG.md update. Update the English changelog or add the 'skip changelog' label when appropriate."
+            exit 1
+          fi
+
+          if ! grep -qx 'CHANGELOG_zh.md' <<< "$changed_files"; then
+            echo "::error::Missing CHANGELOG_zh.md update. Update the Chinese changelog or add the 'skip changelog' label when appropriate."
+            exit 1
+          fi
+
+          echo "Bilingual changelog updates found."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@
 
 ## [Unreleased]
 
+### 🔄 Changed
+
+- Declared JetBrains IDE compatibility from IntelliJ Platform `2023.1` onward, lowered the plugin build baseline to IDEA Community `2023.1.7`, and kept plugin bytecode compatible with Java 17 runtimes.
+- Replaced the plugin verifier target selection with explicit 2023.1 baseline IDEs for CLion, DataGrip, DataSpell, GoLand, IntelliJ IDEA Community, IntelliJ IDEA Ultimate, PhpStorm, PyCharm Community, PyCharm Professional, Rider, RubyMine, and WebStorm.
+
+### 🔧 CI/CD
+
+- Added a bilingual changelog gate requiring regular pull requests to update both `CHANGELOG.md` and `CHANGELOG_zh.md`, with skips for Dependabot, release changelog branches, release branches, and explicit skip labels.
+
+### 📚 Documentation
+
+- Documented the JetBrains 2023.1+ compatibility range in the English and Chinese README files.
+
 ## [4.0.1] - 2026-04-16
 
 ### 🔧 CI/CD

--- a/CHANGELOG_zh.md
+++ b/CHANGELOG_zh.md
@@ -6,6 +6,19 @@
 
 ## [Unreleased]
 
+### 🔄 变更
+
+- 声明兼容 IntelliJ Platform `2023.1` 及后续版本的 JetBrains IDE，将插件构建基线下调到 IDEA Community `2023.1.7`，并保持插件字节码兼容 Java 17 运行时。
+- 将插件验证目标改为显式覆盖 2023.1 基线 IDE：CLion、DataGrip、DataSpell、GoLand、IntelliJ IDEA Community、IntelliJ IDEA Ultimate、PhpStorm、PyCharm Community、PyCharm Professional、Rider、RubyMine 和 WebStorm。
+
+### 🔧 CI/CD
+
+- 新增双语 changelog 门禁，普通 PR 必须同时更新 `CHANGELOG.md` 和 `CHANGELOG_zh.md`；Dependabot、release changelog 分支、release 分支和显式跳过标签除外。
+
+### 📚 文档
+
+- 在英文和中文 README 中补充 JetBrains 2023.1+ 兼容范围说明。
+
 ## [4.0.1]
 
 ### 🔧 CI/CD

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Intercept Wave provides the following core functionalities:
 - **Status Code Testing**: Configure different status codes to test error handling logic
 - **Prefix Filtering**: Support prefix filtering to simplify API access paths
 - **Global Cookie**: Configure global cookies for APIs requiring authentication
+
+## Compatibility
+
+Intercept Wave supports JetBrains IDEs based on the IntelliJ Platform 2023.1 and newer. The plugin is built against the 2023.1 platform baseline and emits Java 17 bytecode for compatibility with 2023.x IDE runtimes.
+
+The plugin verification matrix covers 2023.1 baseline releases for CLion, DataGrip, DataSpell, GoLand, IntelliJ IDEA Community, IntelliJ IDEA Ultimate, PhpStorm, PyCharm Community, PyCharm Professional, Rider, RubyMine, and WebStorm.
 <!-- Plugin description end -->
 
 ### What's New in v4.0

--- a/README_zh.md
+++ b/README_zh.md
@@ -70,6 +70,12 @@ Intercept Wave 提供以下核心功能：
 - **前缀过滤**: 支持配置前缀过滤，简化接口访问路径
 - **全局 Cookie**: 配置全局 Cookie，支持需要认证的 Mock 接口
 
+## 兼容性
+
+Intercept Wave 支持基于 IntelliJ Platform 2023.1 及更新版本的 JetBrains IDE。插件以 2023.1 平台作为兼容基线构建，并输出 Java 17 字节码，以兼容 2023.x IDE 运行时。
+
+插件验证矩阵覆盖以下产品的 2023.1 基线版本：CLion、DataGrip、DataSpell、GoLand、IntelliJ IDEA Community、IntelliJ IDEA Ultimate、PhpStorm、PyCharm Community、PyCharm Professional、Rider、RubyMine 和 WebStorm。
+
 ### v4.0 更新
 
 - 配置中的 `version` 与插件主次版本保持一致（例如 4.0）。现有旧配置可直接使用，保存时会自动写入 `"version": "4.0"`。

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,8 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.gradle.process.CommandLineArgumentProvider
 import java.time.Duration
 
@@ -198,6 +200,16 @@ tasks.withType<Test>().configureEach {
     // Remote Robot + Gson on JDK 21 needs these packages opened for reflective
     // access when deserializing server-side errors and fixture payloads.
     jvmArgs(commonTestJvmArgs + commonTestModuleOpens)
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(17)
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
 }
 
 // Configure UI testing with robot-server plugin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -176,7 +177,20 @@ intellijPlatform {
 
     pluginVerification {
         ides {
-            recommended()
+            create(IntelliJPlatformType.CLion, "2023.1.7")
+            create(IntelliJPlatformType.DataGrip, "2023.1.2")
+            create(IntelliJPlatformType.DataSpell, "2023.1.6")
+            create(IntelliJPlatformType.GoLand, "2023.1.6")
+            create(IntelliJPlatformType.IntellijIdeaCommunity, "2023.1.7")
+            create(IntelliJPlatformType.IntellijIdeaUltimate, "2023.1.7")
+            create(IntelliJPlatformType.PhpStorm, "2023.1.6")
+            create(IntelliJPlatformType.PyCharmCommunity, "2023.1.6")
+            create(IntelliJPlatformType.PyCharmProfessional, "2023.1.6")
+            create(IntelliJPlatformType.Rider, "2023.1.7") {
+                useInstaller = false
+            }
+            create(IntelliJPlatformType.RubyMine, "2023.1.7")
+            create(IntelliJPlatformType.WebStorm, "2023.1.6")
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/zhongmiao-org/intercept-wave
 pluginVersion = 4.0.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 251
+pluginSinceBuild = 231
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 # start with IntelliJ IDEA Community (aligned with CI UI tests)
@@ -16,7 +16,7 @@ platformType = IC
 # start with WebStorm
 #platformType = WS
 #platformVersion = 2026.1
-platformVersion = 2025.1.5
+platformVersion = 2023.1.7
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP

--- a/src/main/kotlin/org/zhongmiao/interceptwave/ui/MockApiDialog.kt
+++ b/src/main/kotlin/org/zhongmiao/interceptwave/ui/MockApiDialog.kt
@@ -140,7 +140,7 @@ class MockApiDialog(
                         )
                     }
                 }.applyToComponent {
-                    icon = AllIcons.Actions.ReformatCode
+                    icon = AllIcons.Actions.PrettyPrint
                     isFocusPainted = false
                 }
             }

--- a/src/main/kotlin/org/zhongmiao/interceptwave/ui/WsConfigSection.kt
+++ b/src/main/kotlin/org/zhongmiao/interceptwave/ui/WsConfigSection.kt
@@ -209,7 +209,7 @@ class WsConfigSection(
     }
 
     private fun createOffBehaviorPanel(): JComponent {
-        val formatButton = JButton(message("mockapi.button.format"), AllIcons.Actions.ReformatCode).apply {
+        val formatButton = JButton(message("mockapi.button.format"), AllIcons.Actions.PrettyPrint).apply {
             UiKit.applyToolbarButtonStyle(this)
             addActionListener { formatMessageArea(offMsgArea) }
         }
@@ -225,7 +225,7 @@ class WsConfigSection(
     }
 
     private fun createPeriodicBehaviorPanel(): JComponent {
-        val formatButton = JButton(message("mockapi.button.format"), AllIcons.Actions.ReformatCode).apply {
+        val formatButton = JButton(message("mockapi.button.format"), AllIcons.Actions.PrettyPrint).apply {
             UiKit.applyToolbarButtonStyle(this)
             addActionListener { formatMessageArea(periodicMsgArea) }
         }

--- a/src/test/kotlin/org/zhongmiao/interceptwave/ui/ProxyGroupTabPanelTest.kt
+++ b/src/test/kotlin/org/zhongmiao/interceptwave/ui/ProxyGroupTabPanelTest.kt
@@ -1,6 +1,7 @@
 package org.zhongmiao.interceptwave.ui
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.zhongmiao.interceptwave.InterceptWaveBundle.message
 import org.zhongmiao.interceptwave.model.HttpRoute
 import org.zhongmiao.interceptwave.model.MockApiConfig
 import org.zhongmiao.interceptwave.model.ProxyConfig
@@ -69,6 +70,6 @@ class ProxyGroupTabPanelTest : BasePlatformTestCase() {
         val panel = ProxyGroupTabPanel(project, missingId, "Missing", 19099, true) {}
         panel.getPanel()
         val urlLabel = panel.javaClass.getDeclaredField("urlValueLabel").apply { isAccessible = true }.get(panel) as JLabel
-        assertEquals("Not running yet", urlLabel.text)
+        assertEquals(message("toolwindow.status.url.placeholder"), urlLabel.text)
     }
 }


### PR DESCRIPTION
## Description

- Lower the plugin minimum supported IntelliJ Platform build from 251 to 231 so IDEs from 2023.1 onward can install it.
- Build against IC 2023.1.7 to catch APIs unavailable on the supported lower bound.
- Emit Java 17 bytecode while continuing to run the build with the existing JDK 21 toolchain.
- Replace the format action icon with PrettyPrint, which exists in the 2023.1 platform API.
- Make the placeholder URL test locale-independent.
- Configure plugin verification for JetBrains 2023 baseline IDEs: CLion, DataGrip, DataSpell, GoLand, IDEA Community, IDEA Ultimate, PhpStorm, PyCharm Community, PyCharm Professional, Rider, RubyMine, and WebStorm. Rider uses useInstaller = false.
- Document the JetBrains 2023.1+ compatibility range in README.md and README_zh.md.
- Add a bilingual changelog gate requiring regular PRs to update both CHANGELOG.md and CHANGELOG_zh.md, plus matching changelog entries for this PR.

## Validation

- ./gradlew help --no-daemon --no-configuration-cache --max-workers=1 --console=plain
- ./gradlew buildPlugin --no-daemon --no-configuration-cache --max-workers=1 --console=plain
- IntelliJ Plugin Verifier CLI against IC 2023.1.7 only: org.zhongmiao.interceptwave:4.0.1 against IC-231.9423.9: Compatible
- Verified generated plugin.xml contains since-build="231".
- Verified compiled class major version is 61 (Java 17).
- git diff --check

## Notes

- Did not run Gradle verifyPlugin locally because it would download every IDE configured in the verifier matrix. Local verification intentionally used one IDEA 2023 baseline IDE.
