### PR TITLE
chore: add prepare release workflow

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -61,7 +61,7 @@
   description: Pull requests with release changelog update
 
 - name: release
-  color: 5319e7
+  color: 0366d6
   description: Release preparation and publishing changes
 
 - name: skip changelog

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,155 @@
+# GitHub Actions Workflow for preparing a reviewed release PR.
+# It bumps gradle.properties, archives English/Chinese changelog entries,
+# and opens or updates a release PR without creating a tag or publishing.
+
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Target SemVer version, for example 4.1.0
+        required: true
+        type: string
+
+jobs:
+  prepare-release:
+    name: Prepare Release PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Fetch Sources
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Prepare Release Branch
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BRANCH="release/v$VERSION"
+          DATE="$(date -u +%Y-%m-%d)"
+          export DATE
+
+          ruby <<'RUBY'
+          version = ENV.fetch("VERSION")
+
+          unless version.match?(/\A\d+\.\d+\.\d+\z/)
+            abort("Invalid SemVer version: #{version}")
+          end
+
+          current = File.read("gradle.properties")[/^pluginVersion\s*=\s*(.+)$/, 1]&.strip
+          abort("Missing pluginVersion in gradle.properties") unless current
+          unless current.match?(/\A\d+\.\d+\.\d+\z/)
+            abort("Invalid current SemVer version: #{current}")
+          end
+
+          current_parts = current.split(".").map(&:to_i)
+          target_parts = version.split(".").map(&:to_i)
+          unless (target_parts <=> current_parts).positive?
+            abort("Target version #{version} must be greater than current version #{current}")
+          end
+          RUBY
+
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action"
+          git fetch origin main "$BRANCH" || true
+          git switch -C "$BRANCH" origin/main
+          mkdir -p build
+
+          ruby <<'RUBY'
+          version = ENV.fetch("VERSION")
+          date = ENV.fetch("DATE")
+
+          EMOJI_HEADINGS = ["### ✨", "### 🔄", "### 🐛", "### 🔧", "### 📚", "### 🧪", "### 📦", "### 🧱"].freeze
+
+          def extract_unreleased(path)
+            content = File.read(path)
+            match = content.match(/^## \[Unreleased\]\s*$\n(?<body>.*?)(?=^## \[|\z)/m)
+            abort("Missing Unreleased section in #{path}") unless match
+
+            body = match[:body].strip
+            abort("Empty Unreleased section in #{path}") if body.empty?
+            unless EMOJI_HEADINGS.any? { |heading| body.include?(heading) }
+              abort("#{path} Unreleased must include at least one emoji changelog heading")
+            end
+
+            body
+          end
+
+          gradle = File.read("gradle.properties")
+          changed = gradle.sub(/^pluginVersion\s*=.*$/, "pluginVersion = #{version}")
+          abort("Missing pluginVersion in gradle.properties") if changed == gradle
+          File.write("gradle.properties", changed)
+
+          def archive_unreleased(path, heading, notes)
+            content = File.read(path)
+            abort("#{path} already contains #{heading}") if content.include?(heading)
+
+            replacement = "## [Unreleased]\n\n#{heading}\n\n#{notes}\n\n"
+            changed = content.sub(/^## \[Unreleased\]\s*$\n.*?(?=^## \[|\z)/m, replacement)
+            abort("Missing Unreleased section in #{path}") if changed == content
+            File.write(path, changed)
+          end
+
+          notes_en = extract_unreleased("CHANGELOG.md")
+          notes_zh = extract_unreleased("CHANGELOG_zh.md")
+
+          archive_unreleased("CHANGELOG.md", "## [#{version}] - #{date}", notes_en)
+          archive_unreleased("CHANGELOG_zh.md", "## [#{version}]", notes_zh)
+
+          body = <<~BODY
+          ## Summary
+          Prepare release `v#{version}`.
+
+          ## Release Notes
+          #{notes_en}
+          BODY
+
+          File.write("build/release-pr-body.md", body)
+          RUBY
+
+          git add gradle.properties CHANGELOG.md CHANGELOG_zh.md
+
+          if git diff --cached --quiet; then
+            echo "No release changes detected."
+          else
+            git commit -m "chore: release v$VERSION"
+          fi
+
+          git push --force-with-lease --set-upstream origin "$BRANCH"
+
+          gh label create release \
+            --description "Release preparation pull request" \
+            --color 0366d6 \
+            --force \
+            || true
+
+          PR_NUMBER="$(gh pr list --head "$BRANCH" --base main --state open --json number --jq '.[0].number // ""')"
+          if [[ -n "$PR_NUMBER" ]]; then
+            gh pr edit "$PR_NUMBER" \
+              --title "chore: release v$VERSION" \
+              --body-file build/release-pr-body.md \
+              --add-label release
+          else
+            gh pr create \
+              --title "chore: release v$VERSION" \
+              --body-file build/release-pr-body.md \
+              --label release \
+              --base main \
+              --head "$BRANCH"
+          fi
+
+          {
+            echo "branch=$BRANCH"
+            echo "version=$VERSION"
+          } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,72 +1,141 @@
-# GitHub Actions Workflow created for handling the release process based on the draft release prepared with the Build workflow.
-# Running the publishPlugin task requires all the following secrets to be provided: PUBLISH_TOKEN, PRIVATE_KEY, PRIVATE_KEY_PASSWORD, CERTIFICATE_CHAIN.
-# See https://plugins.jetbrains.com/docs/intellij/plugin-signing.html for more information.
+# GitHub Actions Workflow for publishing a reviewed release PR.
+# The release PR archives changelog entries and bumps gradle.properties.
+# After the PR is merged, this workflow tags the merge commit, publishes the plugin,
+# uploads the plugin ZIP to a draft GitHub Release, then publishes the release.
 
 name: Release
+
 on:
-  release:
-    types: [prereleased, released]
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 jobs:
-
-  # Prepare and publish the plugin to JetBrains Marketplace repository
   release:
     name: Publish Plugin
+    if: >-
+      github.event.pull_request.merged == true &&
+      (startsWith(github.event.pull_request.head.ref, 'release/v') ||
+      contains(github.event.pull_request.labels.*.name, 'release'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
+      pull-requests: read
     steps:
-
-      # Free GitHub Actions Environment Disk Space
       - name: Maximize Build Space
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: false
           large-packages: false
 
-      # Check out the current repository
       - name: Fetch Sources
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
 
-      # Set up the Java environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
 
-      # Setup Gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: true
 
-      # Update the Unreleased section with the current release note
-      - name: Patch Changelog
-        if: ${{ github.event.release.body != '' }}
-        env:
-          CHANGELOG: ${{ github.event.release.body }}
+      - name: Prepare Release Metadata
+        id: metadata
+        shell: bash
         run: |
-          VERSION_RAW="${{ github.event.release.tag_name }}"
-          VERSION="${VERSION_RAW#v}"
-          RELEASE_NOTE="./build/tmp/release_note.txt"
-          mkdir -p "$(dirname "$RELEASE_NOTE")"
-          echo "$CHANGELOG" > $RELEASE_NOTE
+          set -euo pipefail
 
-          ./gradlew patchChangelog --release-note-file=$RELEASE_NOTE
+          VERSION="$(./gradlew properties --property version --quiet --console=plain | tail -n 1 | cut -f2- -d ' ')"
+          TAG="v$VERSION"
+          RELEASE_NOTE="./build/tmp/release_note.md"
 
-          # Patch Chinese changelog: rename Unreleased -> [VERSION] and add new Unreleased on top
-          if [ -f CHANGELOG_zh.md ]; then
-            awk -v ver="$VERSION" '
-              !done && $0 ~ /^## \[Unreleased\]\s*$/ { print "## [Unreleased]\n\n## [" ver "]"; done=1; next }
-              { print }
-            ' CHANGELOG_zh.md > CHANGELOG_zh.md.tmp && mv CHANGELOG_zh.md.tmp CHANGELOG_zh.md
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid SemVer version in gradle.properties: $VERSION"
+            exit 1
           fi
 
-      # Publish the plugin to JetBrains Marketplace
+          ruby - "$VERSION" "$RELEASE_NOTE" <<'RUBY'
+          require "fileutils"
+
+          version = ARGV.fetch(0)
+          output = ARGV.fetch(1)
+          changelog = File.read("CHANGELOG.md")
+          pattern = /^## \[#{Regexp.escape(version)}\](?: - \d{4}-\d{2}-\d{2})?\s*$\n(?<body>.*?)(?=^## \[|\z)/m
+          match = changelog.match(pattern)
+          abort("Missing CHANGELOG.md section for #{version}") unless match
+
+          body = match[:body].strip
+          abort("Empty CHANGELOG.md section for #{version}") if body.empty?
+
+          FileUtils.mkdir_p(File.dirname(output))
+          File.write(output, body + "\n")
+          RUBY
+
+          {
+            echo "version=$VERSION"
+            echo "tag=$TAG"
+            echo "release_note=$RELEASE_NOTE"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create Release Tag
+        env:
+          TAG: ${{ steps.metadata.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch --tags origin
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action"
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            EXISTING="$(git rev-parse "$TAG^{commit}")"
+            CURRENT="$(git rev-parse HEAD)"
+            if [[ "$EXISTING" != "$CURRENT" ]]; then
+              echo "::error::Tag $TAG already exists at $EXISTING, expected $CURRENT"
+              exit 1
+            fi
+            echo "Tag $TAG already points to current commit."
+          else
+            git tag -a "$TAG" -m "Release $TAG"
+            git push origin "$TAG"
+          fi
+
+      - name: Create or Update Draft Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.metadata.outputs.tag }}
+          RELEASE_NOTE: ${{ steps.metadata.outputs.release_note }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            IS_DRAFT="$(gh release view "$TAG" --json isDraft --jq '.isDraft')"
+            if [[ "$IS_DRAFT" != "true" ]]; then
+              echo "::error::Release $TAG already exists and is not a draft."
+              exit 1
+            fi
+            gh release edit "$TAG" \
+              --title "$TAG" \
+              --notes-file "$RELEASE_NOTE" \
+              --draft=true \
+              --latest=false
+          else
+            gh release create "$TAG" \
+              --draft \
+              --title "$TAG" \
+              --notes-file "$RELEASE_NOTE" \
+              --verify-tag \
+              --latest=false
+          fi
+
       - name: Publish Plugin
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
@@ -75,87 +144,20 @@ jobs:
           PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
         run: ./gradlew publishPlugin
 
-      # Validate generated plugin archive before attaching to GitHub Release
       - name: Validate Plugin Archive
         shell: bash
         run: |
           ls -la ./build/distributions
           unzip -t ./build/distributions/*.zip
 
-      # Upload an artifact as a release asset
       - name: Upload Release Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*.zip
+          TAG: ${{ steps.metadata.outputs.tag }}
+        run: gh release upload "$TAG" ./build/distributions/*.zip --clobber
 
-      # After successful publish, update main branch changelog via PR with auto-merge
-      - name: Check out main branch
-        uses: actions/checkout@v6
-        with:
-          ref: main
-          fetch-depth: 0
-
-      - name: Patch Changelog on main
-        if: ${{ github.event.release.body != '' }}
-        env:
-          CHANGELOG: ${{ github.event.release.body }}
-        run: |
-          VERSION_RAW="${{ github.event.release.tag_name }}"
-          VERSION="${VERSION_RAW#v}"
-          RELEASE_NOTE="./build/tmp/release_note.txt"
-          mkdir -p "$(dirname "$RELEASE_NOTE")"
-          echo "$CHANGELOG" > $RELEASE_NOTE
-
-          ./gradlew patchChangelog --release-note-file=$RELEASE_NOTE
-
-          # Patch Chinese changelog: rename Unreleased -> [VERSION] and add new Unreleased on top
-          if [ -f CHANGELOG_zh.md ]; then
-            awk -v ver="$VERSION" '
-              !done && $0 ~ /^## \[Unreleased\]\s*$/ { print "## [Unreleased]\n\n## [" ver "]"; done=1; next }
-              { print }
-            ' CHANGELOG_zh.md > CHANGELOG_zh.md.tmp && mv CHANGELOG_zh.md.tmp CHANGELOG_zh.md
-          fi
-
-      - name: Create PR for changelog update (auto-merge)
+      - name: Publish GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION_RAW="${{ github.event.release.tag_name }}"
-          VERSION="${VERSION_RAW#v}"
-          BRANCH="changelog/update-$VERSION"
-          LABEL="release changelog"
-
-          git switch -c "$BRANCH"
-          git config user.email "action@github.com"
-          git config user.name "GitHub Action"
-
-          # Stage potential changelog files
-          git add CHANGELOG.md || true
-          if [ -f CHANGELOG_zh.md ]; then
-            git add CHANGELOG_zh.md || true
-          fi
-
-          # Commit only if there are staged changes
-          if ! git diff --cached --quiet; then
-            git commit -m "chore(changelog): update for $VERSION"
-            git push --set-upstream origin "$BRANCH"
-
-            # Ensure label exists
-            gh label create "$LABEL" \
-              --description "Pull requests with release changelog update" \
-              --force \
-              || true
-
-            # Create PR targeting main
-            gh pr create \
-              --title "Changelog update - $VERSION" \
-              --body "This PR updates \`CHANGELOG.md\` replacing Unreleased with \`$VERSION\` and adds a new Unreleased section." \
-              --label "$LABEL" \
-              --base main \
-              --head "$BRANCH"
-
-            # Enable auto-merge (squash); will merge when checks pass
-            gh pr merge --auto --squash "$BRANCH" || true
-          else
-            echo "No changelog changes detected; skipping PR creation."
-          fi
+          TAG: ${{ steps.metadata.outputs.tag }}
+        run: gh release edit "$TAG" --draft=false --latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 ### 🔧 CI/CD
 
 - Added a bilingual changelog gate requiring regular pull requests to update both `CHANGELOG.md` and `CHANGELOG_zh.md`, with skips for Dependabot, release changelog branches, release branches, and explicit skip labels.
+- Added a manual Prepare Release workflow that validates a target SemVer version, bumps `pluginVersion`, archives bilingual changelog entries, and opens or updates a reviewed release PR.
+- Changed publishing to run after a reviewed release PR is merged, creating an idempotent release tag, publishing to JetBrains Marketplace, uploading the plugin ZIP, and publishing the GitHub Release.
 
 ### 📚 Documentation
 

--- a/CHANGELOG_zh.md
+++ b/CHANGELOG_zh.md
@@ -14,6 +14,8 @@
 ### 🔧 CI/CD
 
 - 新增双语 changelog 门禁，普通 PR 必须同时更新 `CHANGELOG.md` 和 `CHANGELOG_zh.md`；Dependabot、release changelog 分支、release 分支和显式跳过标签除外。
+- 新增手动 Prepare Release workflow，用于校验目标 SemVer 版本、更新 `pluginVersion`、归档中英文 changelog，并创建或更新需要 review 的 release PR。
+- 将发布流程改为在 release PR 合并后执行，自动创建幂等 release tag、发布到 JetBrains Marketplace、上传插件 ZIP，并发布 GitHub Release。
 
 ### 📚 文档
 


### PR DESCRIPTION
## Description

- Add a manual Prepare Release workflow that creates or updates reviewed release PRs from `main`.
- Validate target SemVer versions against `pluginVersion`, bump `pluginVersion`, and archive English/Chinese Unreleased changelog notes into the target version section.
- Change publishing to run after a reviewed release PR is merged, then create an idempotent tag, publish to JetBrains Marketplace, upload the plugin ZIP, and publish the GitHub Release.
- Ensure the `release` label is available and document the release CI changes in both changelogs.

## Validation

- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/prepare-release.yml"); YAML.load_file(".github/workflows/release.yml")'
- ./gradlew help --no-daemon --no-configuration-cache --max-workers=1 --console=plain
- Local release metadata extraction check for current pluginVersion 4.0.1

## Notes

- Did not run the publishing workflow locally because it requires GitHub PR/release events, Marketplace secrets, and real tag permissions.
- Did not run verifyPlugin to avoid downloading the configured IDE verifier targets.
