### PR TITLE
fix: gate release publishing on tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
       (startsWith(github.event.pull_request.head.ref, 'release/v') ||
       contains(github.event.pull_request.labels.*.name, 'release'))
     runs-on: ubuntu-latest
+    env:
+      UPSTREAM_COMPOSE_FILE: docker/docker-compose.upstream.yml
     permissions:
       contents: write
       pull-requests: read
@@ -44,6 +46,35 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: true
+
+      - name: Start Upstream Services
+        run: |
+          docker compose -f "$UPSTREAM_COMPOSE_FILE" up -d
+          echo "Waiting for upstream health..."
+          for i in {1..60}; do
+            if curl -fsS http://localhost:9000/health >/dev/null 2>&1; then
+              echo "Upstream is healthy"
+              break
+            fi
+            sleep 2
+          done
+          curl -fsS http://localhost:9000/health || (echo "Upstream failed to become healthy" && docker compose -f "$UPSTREAM_COMPOSE_FILE" logs --no-log-prefix && exit 1)
+
+      - name: Clean Test Environment
+        run: |
+          rm -rf build/idea-sandbox
+          rm -rf build/tmp
+          rm -rf ~/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea
+
+      - name: Run Release Tests
+        run: ./gradlew clean check --no-configuration-cache --rerun-tasks
+        env:
+          CI: "true"
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx2048m"
+
+      - name: Stop Upstream Services
+        if: ${{ always() }}
+        run: docker compose -f "$UPSTREAM_COMPOSE_FILE" down -v --remove-orphans || true
 
       - name: Prepare Release Metadata
         id: metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ## [Unreleased]
 
+### 🐛 Fixed
+
+- Kept persisted configuration schema versions pinned to the current config schema instead of deriving them from the plugin release version.
+
+### 🔧 CI/CD
+
+- Added a release-time test gate before creating tags, publishing to JetBrains Marketplace, or publishing GitHub Releases.
+
 ## [4.1.0] - 2026-04-30
 
 ### 🔄 Changed

--- a/CHANGELOG_zh.md
+++ b/CHANGELOG_zh.md
@@ -6,6 +6,14 @@
 
 ## [Unreleased]
 
+### 🐛 修复
+
+- 配置文件 schema 版本固定使用当前配置 schema 版本，不再从插件发布版本推导，避免发布小版本后写入不受支持的配置版本。
+
+### 🔧 CI/CD
+
+- 在创建 tag、发布到 JetBrains Marketplace、发布 GitHub Release 前增加 release 测试门禁。
+
 ## [4.1.0]
 
 ### 🔄 变更

--- a/src/main/kotlin/org/zhongmiao/interceptwave/services/ConfigService.kt
+++ b/src/main/kotlin/org/zhongmiao/interceptwave/services/ConfigService.kt
@@ -15,11 +15,8 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
-import com.intellij.ide.plugins.PluginManagerCore
-import org.zhongmiao.interceptwave.util.PluginConstants
 import org.zhongmiao.interceptwave.util.Env
 import java.io.File
-import java.lang.reflect.Modifier
 import java.util.UUID
 
 /**
@@ -91,7 +88,7 @@ class ConfigService(private val project: Project) {
                 val loaded = json.decodeFromString(RootConfig.serializer(), content)
                 val migrated = migrateToLatest(loaded, jsonObject)
                 val fixed = normalizeAndMinifyMockData(migrated.second)
-                val withVersion = ensureVersionMajorMinor(fixed.second)
+                val withVersion = ensureCurrentConfigVersion(fixed.second)
                 val changed = migrated.first || fixed.first || withVersion.version != loaded.version
                 persistAndReloadIfNeeded(changed, withVersion)
             } else {
@@ -99,13 +96,13 @@ class ConfigService(private val project: Project) {
                 val migratedV2 = migrateFromV1ToV2(content)
                 val migrated = migrateToLatest(migratedV2, null)
                 val fixed = normalizeAndMinifyMockData(migrated.second)
-                val withVersion = ensureVersionMajorMinor(fixed.second)
+                val withVersion = ensureCurrentConfigVersion(fixed.second)
                 persistAndReloadIfNeeded(true, withVersion, notifyMigration = true)
             }
         }
 
         val created = createDefaultConfig()
-        val withVersion = ensureVersionMajorMinor(created)
+        val withVersion = ensureCurrentConfigVersion(created)
         return persistAndReloadIfNeeded(withVersion.version != created.version, withVersion)
     }
 
@@ -199,62 +196,13 @@ class ConfigService(private val project: Project) {
         return changed to root.copy(proxyGroups = normalizedGroups)
     }
 
-    /**
-     * 计算当前插件的主次版本号（x.y）。
-     * 优先从插件管理器读取，失败时回退为现有 version 的主次或当前配置版本。
-     */
-    private fun currentMajorMinor(existing: String? = null): String {
-        val fallbackExisting = existing ?: CURRENT_CONFIG_VERSION
-        val fallback = fallbackExisting.split('.').let {
-            if (it.size >= 2) it[0] + "." + it[1] else CURRENT_CONFIG_VERSION
+    /** 确保配置 version 使用当前 schema 版本，而不是插件发布版本。 */
+    private fun ensureCurrentConfigVersion(root: RootConfig): RootConfig {
+        return if (root.version != CURRENT_CONFIG_VERSION) {
+            root.copy(version = CURRENT_CONFIG_VERSION)
+        } else {
+            root
         }
-        // Prefer explicit system property override for tests/headless
-        val sys = runCatching { System.getProperty("intercept.wave.version") }.getOrNull()
-        val sysParts = sys?.split('.')
-        if (sysParts != null && sysParts.size >= 2) return sysParts[0] + "." + sysParts[1]
-
-        return try {
-            val ver = resolvePluginVersionReflectively()
-            val parts = ver?.split('.')
-            if (parts != null && parts.size >= 2) parts[0] + "." + parts[1] else fallback
-        } catch (_: Throwable) {
-            // Fallback to sys or provided existing
-            if (sysParts != null && sysParts.size >= 2) sysParts[0] + "." + sysParts[1] else fallback
-        }
-    }
-
-    /**
-     * Uses reflection to avoid generating bytecode that references PluginId.Companion,
-     * which is not available on older IDE builds verified by the plugin verifier.
-     */
-    private fun resolvePluginVersionReflectively(): String? {
-        val pluginIdClass = Class.forName("com.intellij.openapi.extensions.PluginId")
-        val pluginIdFactory = pluginIdClass.methods.firstOrNull { method ->
-            Modifier.isStatic(method.modifiers) &&
-                (method.name == "getId" || method.name == "findId") &&
-                method.parameterCount == 1 &&
-                method.parameterTypes[0] == String::class.java
-        } ?: return null
-
-        val pluginId = pluginIdFactory.invoke(null, PluginConstants.PLUGIN_ID) ?: return null
-        val getPluginMethod = PluginManagerCore::class.java.methods.firstOrNull { method ->
-            method.name == "getPlugin" &&
-                method.parameterCount == 1 &&
-                method.parameterTypes[0].name == "com.intellij.openapi.extensions.PluginId"
-        } ?: return null
-
-        val pluginDescriptor = getPluginMethod.invoke(null, pluginId) ?: return null
-        val getVersionMethod = pluginDescriptor.javaClass.methods.firstOrNull { method ->
-            method.name == "getVersion" && method.parameterCount == 0
-        } ?: return null
-
-        return getVersionMethod.invoke(pluginDescriptor) as? String
-    }
-
-    /** 确保配置 version 为当前插件的 x.y */
-    private fun ensureVersionMajorMinor(root: RootConfig): RootConfig {
-        val desired = currentMajorMinor(root.version)
-        return if (root.version != desired) root.copy(version = desired) else root
     }
 
     /**
@@ -323,7 +271,7 @@ class ConfigService(private val project: Project) {
     fun saveRootConfig(config: RootConfig) {
         try {
             val routed = ensureHttpRoutes(config).second
-            val versioned = ensureVersionMajorMinor(routed)
+            val versioned = ensureCurrentConfigVersion(routed)
             configFile.writeText(json.encodeToString(versioned))
             rootConfig = versioned
             thisLogger().info("Root config saved successfully")
@@ -449,7 +397,7 @@ class ConfigService(private val project: Project) {
                     migrateV3ToV4(current, rootJson)
                 }
                 else -> {
-                    val normalized = ensureVersionMajorMinor(current)
+                    val normalized = ensureCurrentConfigVersion(current)
                     if (normalized.version == current.version) {
                         error("Unsupported config version: ${current.version}")
                     }

--- a/src/test/kotlin/org/zhongmiao/interceptwave/services/ConfigServiceMigrationTest.kt
+++ b/src/test/kotlin/org/zhongmiao/interceptwave/services/ConfigServiceMigrationTest.kt
@@ -95,7 +95,7 @@ class ConfigServiceMigrationTest : BasePlatformTestCase() {
         assertEquals("/api/user", group.routes[0].mockApis.single().path)
     }
 
-    fun `test ensureVersionMajorMinor normalizes to major_minor`() {
+    fun `test saved config is normalized to current schema version`() {
         // Prepare minimal v2 config with a different version
         val service = ConfigService(project)
         val root = service.getRootConfig()

--- a/src/test/kotlin/org/zhongmiao/interceptwave/services/ConfigServiceTest.kt
+++ b/src/test/kotlin/org/zhongmiao/interceptwave/services/ConfigServiceTest.kt
@@ -59,15 +59,14 @@ class ConfigServiceTest {
     }
 
     @Test
-    fun saveRootConfig_appliesMajorMinorVersion() {
+    fun saveRootConfig_usesCurrentConfigVersion() {
         val dir = Files.createTempDirectory("iw-conf2").toFile()
-        // Provide plugin version via system property fallback
-        System.setProperty("intercept.wave.version", "3.7.9")
+        System.setProperty("intercept.wave.version", "4.1.0")
         val svc = ConfigService(fakeProject(dir))
         val custom = RootConfig(version = "1.0", proxyGroups = mutableListOf())
         svc.saveRootConfig(custom)
         val loaded = svc.getRootConfig()
-        assertEquals("3.7", loaded.version)
+        assertEquals(ConfigService.CURRENT_CONFIG_VERSION, loaded.version)
     }
 
     @Test
@@ -301,23 +300,14 @@ class ConfigServiceTest {
     }
 
     @Test
-    fun currentMajorMinor_uses_system_property_major_minor() {
-        val dir = Files.createTempDirectory("iw-conf-current-version").toFile()
+    fun ensureCurrentConfigVersion_ignores_plugin_version_override() {
+        val dir = Files.createTempDirectory("iw-conf-current-fallback").toFile()
         System.setProperty("intercept.wave.version", "8.9.7")
         val svc = ConfigService(fakeProject(dir))
+        val root = RootConfig(version = "9")
 
-        val actual = invokePrivate(svc, "currentMajorMinor", "1.0") as String
-        assertEquals("8.9", actual)
-    }
-
-    @Test
-    fun currentMajorMinor_falls_back_to_current_config_version_when_existing_is_not_major_minor() {
-        val dir = Files.createTempDirectory("iw-conf-current-fallback").toFile()
-        System.clearProperty("intercept.wave.version")
-        val svc = ConfigService(fakeProject(dir))
-
-        val actual = invokePrivate(svc, "currentMajorMinor", "9") as String
-        assertEquals(ConfigService.CURRENT_CONFIG_VERSION, actual)
+        val actual = invokePrivate(svc, "ensureCurrentConfigVersion", root) as RootConfig
+        assertEquals(ConfigService.CURRENT_CONFIG_VERSION, actual.version)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- keep persisted config versions pinned to the current config schema version instead of deriving them from the plugin release version
- add a release-time test gate before tag creation, Marketplace publishing, ZIP upload, and GitHub Release publishing
- update bilingual changelog entries for the fix

## Test Plan
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'
- ./gradlew test --tests org.zhongmiao.interceptwave.services.ConfigServiceMigrationTest --no-daemon --no-configuration-cache --max-workers=1 --console=plain
- ./gradlew test --tests org.zhongmiao.interceptwave.services.ConfigServiceTest --no-daemon --no-configuration-cache --max-workers=1 --console=plain
- CI=true GRADLE_OPTS="-Dorg.gradle.jvmargs=-Xmx2048m" ./gradlew test --tests org.zhongmiao.interceptwave.services.ConfigServiceMigrationTest --no-daemon --no-configuration-cache --max-workers=1 --console=plain
- ./gradlew help --no-daemon --no-configuration-cache --max-workers=1 --console=plain

## Notes
- Full local release gate simulation was blocked because Docker daemon is not running locally, so upstream containers could not be started.